### PR TITLE
add bash script for cross compile

### DIFF
--- a/buildAll.sh
+++ b/buildAll.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+echo "buildAll TxPortMap..."
+os_archs="darwin:amd64 darwin:arm64 freebsd:386 freebsd:amd64 linux:386 linux:amd64 linux:arm linux:arm64 windows:386 windows:amd64 linux:mips64 linux:mips64le linux:mips:softfloat linux:mipsle:softfloat"
+LDFLAGS="-s -w"
+for n in $os_archs
+do
+    os=$(echo $n | cut -d : -f 1)
+    arch=$(echo $n | cut -d : -f 2)
+    gomips=$(echo $n | cut -d : -f 3)
+    target_suffix="${os}_${arch}"
+    echo "Build ${os}_${arch} ...."
+    env CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" GOMIPS="${gomips}" go build -trimpath -ldflags "${LDFLAGS}" -o ./release/TxPortMap_"${target_suffix}" ./cmd/TxPortMap/TxPortMap.go
+    echo "Build ${os}_${arch} done"
+done
+
+mv ./release/TxPortMap_windows_386 ./release/TxPortMap_windows_386.exe
+mv ./release/TxPortMap_windows_amd64 ./release/TxPortMap__windows_amd64.exe

--- a/buildAll.sh
+++ b/buildAll.sh
@@ -15,4 +15,4 @@ do
 done
 
 mv ./release/TxPortMap_windows_386 ./release/TxPortMap_windows_386.exe
-mv ./release/TxPortMap_windows_amd64 ./release/TxPortMap__windows_amd64.exe
+mv ./release/TxPortMap_windows_amd64 ./release/TxPortMap_windows_amd64.exe


### PR DESCRIPTION
# add bash script for cross compile
```
$ ./buildAll.sh
buildAll TxPortMap...
Build darwin_amd64 ....
Build darwin_amd64 done
Build darwin_arm64 ....
Build darwin_arm64 done
Build freebsd_386 ....
Build freebsd_386 done
Build freebsd_amd64 ....
Build freebsd_amd64 done
Build linux_386 ....
Build linux_386 done
Build linux_amd64 ....
Build linux_amd64 done
Build linux_arm ....
Build linux_arm done
Build linux_arm64 ....
Build linux_arm64 done
Build windows_386 ....
Build windows_386 done
Build windows_amd64 ....
Build windows_amd64 done
Build linux_mips64 ....
Build linux_mips64 done
Build linux_mips64le ....
Build linux_mips64le done
Build linux_mips ....
Build linux_mips done
Build linux_mipsle ....
Build linux_mipsle done
```